### PR TITLE
Allow empty baseURL

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ export class JSONHTTPError extends HTTPError {
 }
 
 export default class API {
-  constructor(apiURL, options) {
+  constructor(apiURL = '', options) {
     this.apiURL = apiURL;
     if (this.apiURL.match(/\/[^\/]?/)) { // eslint-disable-line no-useless-escape
       this._sameOrigin = true;


### PR DESCRIPTION
In case you don't want to set a baseURL, this sets it to a blank string.  It enables instantiation with empty args.