### PR TITLE
Add isomorphic-fetch for node (fixes #7)

### DIFF
--- a/node.js
+++ b/node.js
@@ -1,0 +1,3 @@
+require("isomorphic-fetch");
+
+module.exports = require("./lib");

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "3.3.0",
   "author": "Mathias Biilmann Christensen",
   "bugs": "https://github.com/netlify/micro-api-client/issues",
+  "dependencies": {
+    "isomorphic-fetch": "^3.0.0"
+  },
   "devDependencies": {
     "babel-cli": "^6.8.0",
     "babel-eslint": "^8.2.1",
@@ -18,7 +21,8 @@
     "prettier": "^1.10.1"
   },
   "files": [
-    "lib"
+    "lib",
+    "node.js"
   ],
   "homepage": "https://github.com/netlify/micro-api-client",
   "keywords": [
@@ -27,16 +31,17 @@
     "netlify"
   ],
   "license": "ISC",
-  "main": "lib/index.js",
+  "main": "node.js",
+  "browser": "lib/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/netlify/micro-api-client.git"
   },
   "scripts": {
     "compile": "babel src -d lib",
-    "format": "eslint . --fix && prettier --write 'src/**/*.js'",
+    "format": "eslint . --fix && prettier --write 'src/**/*.js' 'node.js'",
     "prepublish": "npm run compile",
-    "prettier-preview": "prettier --list-different 'src/**/*.js'",
+    "prettier-preview": "prettier --list-different 'src/**/*.js' 'node.js'",
     "test": "eslint ."
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1603,6 +1603,14 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -1796,6 +1804,11 @@ nan@^2.3.0:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-pre-gyp@^0.6.39:
   version "0.6.39"
@@ -2482,6 +2495,11 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+whatwg-fetch@^3.4.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 which@^1.2.9:
   version "1.3.0"


### PR DESCRIPTION
Polyfills the fetch API in Node.js. This is done with a wrapper script to avoid a relatively large Babel output. 

I chose to use isomorphic-fetch so that importing using the `main` field will still work in browsers, and simply pull in the polyfill. Bundlers should prioritize the [`browser` field](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#browser).